### PR TITLE
Support :global() as class modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 a { }
 ```
 
-2. Remove :global as part of a selecotr
+2. Remove :global as part of a selector
 ```css
 .root :global .text { margin: 0 6px; }
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [ci-img]:  https://travis-ci.org/princetoad/postcss-remove-global.svg
 [ci]:      https://travis-ci.org/princetoad/postcss-remove-global
 
-## Support three cases
+## Support four cases
 
 1. Remove :global as a single selector
 ```css
@@ -28,7 +28,16 @@ a { }
 .root .text { margin: 0 6px; }
 ```
 
-3. Remove :global as part of params of @keyframe
+3. Remove :global() as class modifier
+```css
+.root :global(.text) { margin: 0 6px; }
+```
+
+```css
+.root .text { margin: 0 6px; }
+```
+
+4. Remove :global as part of params of @keyframe
 ```css
 @keyframes :global(zoomIn) { }
 ```

--- a/index.js
+++ b/index.js
@@ -7,11 +7,15 @@ module.exports = postcss.plugin(pluginName, () => (root) => {
     root.walkRules(rule => {
         // :global as nested selector
         const globalReg = /:global(\s+)/;
+        const globalAsModifier = /:global\((\S+?)\)/g;
+
         if (rule.selector === ':global') {
             rule.parent.append(...rule.nodes);
             rule.remove();
         } else if (rule.selector.match(globalReg)) {
             rule.selector = rule.selector.replace(globalReg, '');
+        } else if (rule.selector.match(globalAsModifier)) {
+            rule.selector = rule.selector.replace(globalAsModifier, '$1');
         }
     });
     // :global in AtRules

--- a/index.test.js
+++ b/index.test.js
@@ -28,6 +28,20 @@ it('remove :global - as part of selector with multiple spaces', () => {
         { });
 });
 
+it('remove :global - as a class modifier', () => {
+    return run(
+        '.root :global(.text) { margin: 0 6px; }',
+        '.root .text { margin: 0 6px; }',
+        { });
+});
+
+it('remove :global - as a class modifier, multiple', () => {
+    return run(
+        '.root :global(.text):not(:global(.text-small)) { margin: 0 6px; }',
+        '.root .text:not(.text-small) { margin: 0 6px; }',
+        { });
+});
+
 it('remove :global - as part of @keyframe params', () => {
     return run('@keyframes :global(zoomIn) { }', '@keyframes zoomIn { }', { });
 });


### PR DESCRIPTION
Adds support for use case of :global(.text) -> .text.

Adds tests, for this use case.